### PR TITLE
Added recursive readdir per #6 and using a fork pending PR acceptance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
+const recursive = require('recursive-readdir');
 const path = require('path');
-const fs = require('fs');
 const os = require('os');
 
 if (process.platform !== 'win32') {
@@ -36,7 +36,7 @@ const FONT_DIRS = {
  * @return {Promise} - Array of fonts
  */
 exports.getFontsInDirectory = dir => new Promise((resolve) => {
-  fs.readdir(dir, (err, files) => {
+  recursive(dir, (err, files) => {
     if (err) {
       resolve([]);
       return;

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ exports.getFontsInDirectory = dir => new Promise((resolve) => {
       resolve([]);
       return;
     }
-    resolve(files.map(f => path.join(dir, f)));
+    resolve(files);
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,25 +1,11 @@
 {
   "name": "os-fonts",
-  "version": "0.3.1",
   "description": "Retrieve fonts available on your OS.",
-  "keywords": [
-    "fonts",
-    "font",
-    "os",
-    "system"
-  ],
-  "main": "index.js",
-  "scripts": {
-    "lint": "eslint index.js __tests",
-    "test": "npm run lint && jest --coverage"
-  },
+  "version": "0.3.1",
   "author": "Vu Tran <vu@vu-tran.com>",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/vutran/os-fonts.git"
+  "dependencies": {
+    "recursive-readdir": "github:niftylettuce/recursive-readdir"
   },
-  "dependencies": {},
   "devDependencies": {
     "babel-jest": "^16.0.0",
     "babel-plugin-transform-async-to-generator": "^6.16.0",
@@ -30,5 +16,21 @@
     "eslint-plugin-async": "^0.1.1",
     "eslint-plugin-import": "^2.0.1",
     "jest": "^16.0.2"
+  },
+  "keywords": [
+    "font",
+    "fonts",
+    "os",
+    "system"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vutran/os-fonts.git"
+  },
+  "scripts": {
+    "lint": "eslint index.js __tests",
+    "test": "npm run lint && jest --coverage"
   }
 }


### PR DESCRIPTION
This commit adds support for Ubuntu since there are no files read on those platforms since we need to traverse through all folders in each font folder.  Might as well do it for other platforms too?

Also, this uses a specific fork of the `recursive-readdir` project per https://github.com/jergason/recursive-readdir/pull/35 (I just forked the person's repo who made this PR).

Lastly the tests fail right now since I don't mock `fs.stat` I believe that the `recursive-readdir` project does.  Just try to pull this locally and run tests.

```js
λ ~/Public/os-fonts/ master npm test

> os-fonts@0.3.1 test /Users/user/Public/os-fonts
> npm run lint && jest --coverage

> os-fonts@0.3.1 lint /Users/user/Public/os-fonts
> eslint index.js __tests


 FAIL  __tests__/index.js
  ● os-fonts › should retrieve some fonts

    TypeError: fs.stat is not a function

      at node_modules/recursive-readdir/index.js:42:10
      at Array.forEach (native)
      at node_modules/recursive-readdir/index.js:40:11
      at Object.<anonymous>.fs.readdir (__mocks__/fs.js:33:12)
      at readdir (node_modules/recursive-readdir/index.js:29:6)
      at index.js:39:5
      at Object.<anonymous>.exports.getFontsInDirectory (index.js:38:124)
      at Object.<anonymous>.exports.getAll (index.js:54:263)
      at _callee$ (__tests__/index.js:14:52)
      at tryCatch (node_modules/regenerator-runtime/runtime.js:62:40)
      at GeneratorFunctionPrototype.invoke [as _invoke] (node_modules/regenerator-runtime/runtime.js:336:22)
      at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (node_modules/regenerator-runtime/runtime.js:95:21)
      at step (__tests__/index.js:3:405)
      at __tests__/index.js:3:635
      at Object.<anonymous> (__tests__/index.js:3:316)
      at process._tickCallback (internal/process/next_tick.js:103:7)

  ● os-fonts › should get all network fonts

    TypeError: fs.stat is not a function

      at node_modules/recursive-readdir/index.js:42:10
      at Array.forEach (native)
      at node_modules/recursive-readdir/index.js:40:11
      at Object.<anonymous>.fs.readdir (__mocks__/fs.js:33:12)
      at readdir (node_modules/recursive-readdir/index.js:29:6)
      at index.js:39:5
      at Object.<anonymous>.exports.getFontsInDirectory (index.js:38:124)
      at Object.<anonymous>.exports.getAll (index.js:54:263)
      at _callee4$ (__tests__/index.js:39:52)
      at tryCatch (node_modules/regenerator-runtime/runtime.js:62:40)
      at GeneratorFunctionPrototype.invoke [as _invoke] (node_modules/regenerator-runtime/runtime.js:336:22)
      at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (node_modules/regenerator-runtime/runtime.js:95:21)
      at step (__tests__/index.js:3:405)
      at __tests__/index.js:3:635
      at Object.<anonymous> (__tests__/index.js:3:316)
      at process._tickCallback (internal/process/next_tick.js:103:7)

  os-fonts
    ✕ should retrieve some fonts (13ms)
    ✓ should retrieve no fonts (3ms)
    ✓ should retrieve user fonts (1ms)
    ✕ should get all network fonts (2ms)
    ✓ should return nothing for readdir errors (2ms)

----------|----------|----------|----------|----------|----------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------|----------|----------|----------|----------|----------------|
All files |    93.75 |       80 |       80 |      100 |                |
 index.js |    93.75 |       80 |       80 |      100 |                |
----------|----------|----------|----------|----------|----------------|
Test Suites: 1 failed, 1 total
Tests:       2 failed, 3 passed, 5 total
Snapshots:   0 total
Time:        2.514s
Ran all test suites.
npm ERR! Test failed.  See above for more details.
```