### PR TITLE
Change handling of default usetype

### DIFF
--- a/__mocks__/recursive-readdir.js
+++ b/__mocks__/recursive-readdir.js
@@ -9,7 +9,7 @@ let mockError = false;
  * @param {Function} callback
  */
 const recursiveReaddir = (directory, callback) => {
-  callback.call(null, mockError, mockFiles);
+    callback.call(null, mockError, mockFiles);
 };
 
 /**
@@ -17,8 +17,8 @@ const recursiveReaddir = (directory, callback) => {
  *
  * @param {String[]} files - An array of files
  */
-recursiveReaddir.__setFiles = (files) => {
-  mockFiles = files;
+recursiveReaddir.__setFiles = files => {
+    mockFiles = files;
 };
 
 /**
@@ -26,8 +26,8 @@ recursiveReaddir.__setFiles = (files) => {
  *
  * @param {Boolean} flag - Set to true to return an err
  */
-recursiveReaddir.__setReturnError = (flag) => {
-  mockError = flag;
+recursiveReaddir.__setReturnError = flag => {
+    mockError = flag;
 };
 
 module.exports = recursiveReaddir;

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -3,46 +3,38 @@ import m from '../';
 jest.mock('recursive-readdir');
 
 describe('os-fonts', () => {
-  const recursive = require('recursive-readdir');
+    const recursive = require('recursive-readdir');
 
-  it('should retrieve some fonts', async () => {
-    // set up mock data
-    recursive.__setFiles([
-      'foo.ttf',
-      'bar.ttf',
-    ]);
-    const fonts = await m.getAll();
-    expect(fonts.length).toBe(2);
-  });
+    it('should retrieve some fonts', async () => {
+        // set up mock data
+        recursive.__setFiles(['foo.ttf', 'bar.ttf']);
+        const fonts = await m.getAll();
+        expect(fonts.length).toBe(2);
+    });
 
-  it('should retrieve no fonts', async () => {
-    recursive.__setFiles([]);
-    const fonts = await m.getAll();
-    expect(fonts.length).toBe(0);
-  });
+    it('should retrieve no fonts', async () => {
+        recursive.__setFiles([]);
+        const fonts = await m.getAll();
+        expect(fonts.length).toBe(0);
+    });
 
-  it('should retrieve user fonts', async () => {
-    // set up mock data
-    recursive.__setFiles([]);
-    const fonts = await m.getAll('user');
-    expect(fonts.length).toBe(0);
-  });
+    it('should retrieve user fonts', async () => {
+        // set up mock data
+        recursive.__setFiles([]);
+        const fonts = await m.getAll('user');
+        expect(fonts.length).toBe(0);
+    });
 
-  it('should get all network fonts', async () => {
-    // set up mock data
-    recursive.__setFiles([
-      'foo.ttf',
-      'bar.ttf',
-      'baz.ttf',
-      'qux.ttf',
-    ]);
-    const fonts = await m.getAll('network');
-    expect(fonts.length).toBe(4);
-  });
+    it('should get all network fonts', async () => {
+        // set up mock data
+        recursive.__setFiles(['foo.ttf', 'bar.ttf', 'baz.ttf', 'qux.ttf']);
+        const fonts = await m.getAll('network');
+        expect(fonts.length).toBe(4);
+    });
 
-  it('should return nothing for readdir errors', async () => {
-    recursive.__setReturnError(true);
-    const fonts = await m.getAll('network');
-    expect(fonts.length).toBe(0);
-  });
+    it('should return nothing for readdir errors', async () => {
+        recursive.__setReturnError(true);
+        const fonts = await m.getAll('network');
+        expect(fonts.length).toBe(0);
+    });
 });

--- a/index.js
+++ b/index.js
@@ -30,6 +30,8 @@ const FONT_DIRS = {
     },
 };
 
+const DEFAULT_DIR = FONT_DIRS[process.platform]['system'];
+
 /**
  * Retrieve all font files in the given directory.
  *
@@ -38,6 +40,7 @@ const FONT_DIRS = {
  */
 exports.getFontsInDirectory = dir =>
     new Promise(resolve => {
+        dir = dir || DEFAULT_DIR;
         recursive(dir, (err, files) => {
             if (err) {
                 resolve([]);
@@ -55,6 +58,7 @@ exports.getFontsInDirectory = dir =>
  */
 exports.getFontsInDirectorySync = dir => {
     try {
+        dir = dir || DEFAULT_DIR;
         return recursiveSync(dir);
     } catch (err) {
         return [];
@@ -64,11 +68,11 @@ exports.getFontsInDirectorySync = dir => {
 /**
  * Get all fonts.
  *
- * @param {String} - The use type.
+ * @param {String} - The use type. Default is 'system'.
  * @return {Promise} - An array of fonts available
  */
-exports.getAll = (useType = 'system') =>
+exports.getAll = useType =>
     exports.getFontsInDirectory(FONT_DIRS[process.platform][useType]);
 
-exports.getAllSync = (useType = 'system') =>
+exports.getAllSync = useType =>
     exports.getFontsInDirectorySync(FONT_DIRS[process.platform][useType]);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/vutran/os-fonts.git"
   },
   "scripts": {
-    "lint": "prettier --single-quote --trailing-comma=es5 --print-width=90 --tab-width=4 --write '{__{mocks,test}__/*.js' 'index.js'",
+    "lint": "prettier --single-quote --trailing-comma=es5 --print-width=90 --tab-width=4 --write \"__{mocks,tests}__/*.js\" \"index.js\"",
     "precommit": "npm run lint",
     "test": "jest --coverage"
   }


### PR DESCRIPTION
In older node versions the lib is failing because it is not supporting the default parameter value.
 #13 